### PR TITLE
Add payload to complete event

### DIFF
--- a/.changeset/rare-onions-explode.md
+++ b/.changeset/rare-onions-explode.md
@@ -1,0 +1,5 @@
+---
+"@complyco/client-web": patch
+---
+
+Add payload to child complete event

--- a/packages/client-web/src/iframe/communicator.ts
+++ b/packages/client-web/src/iframe/communicator.ts
@@ -1,3 +1,5 @@
+import { StateType } from "../api/getTasks";
+
 // Events sent from the child iframe to the parent iframe
 export enum ChildEventType {
   NEEDS_AUTHORIZATION = "needs_authorization",
@@ -16,6 +18,11 @@ type SizePayload = {
   size: "small" | "large";
 };
 
+type CompletePayload = {
+  lastHumanAction: StateType.Scrolled | StateType.Accepted | StateType.Rejected | StateType.Signed | undefined;
+  isTerminalAction: boolean;
+};
+
 type ChildNeedsAuthorizationEvent = {
   type: ChildEventType.NEEDS_AUTHORIZATION;
 };
@@ -31,6 +38,7 @@ type ChildCloseEvent = {
 
 type ChildCompleteEvent = {
   type: ChildEventType.COMPLETE;
+  payload: CompletePayload;
 };
 
 type ChildHealthResponseEvent = {


### PR DESCRIPTION
This will help the fintech determine what to do after a consent/task is complete. For example, they can choose to chose the dialog after a terminal action.