### PR TITLE
Require caller to pass in their own iframe for use

### DIFF
--- a/.changeset/eight-points-marry.md
+++ b/.changeset/eight-points-marry.md
@@ -1,0 +1,5 @@
+---
+"@complyco/client-web": major
+---
+
+Require iframe to be passed when initializing

--- a/packages/client-web/src/iframe/manager.ts
+++ b/packages/client-web/src/iframe/manager.ts
@@ -1,5 +1,10 @@
 import { ComplyCoAPIAuth } from "../auth";
-import { ParentIframeCommunicator, ParentEventType, type CompletePayload, type ChildCompleteEvent } from "./communicator";
+import {
+  ParentIframeCommunicator,
+  ParentEventType,
+  type CompletePayload,
+  type ChildCompleteEvent,
+} from "./communicator";
 
 export type ShutdownErrorReason = {
   reason: "error";
@@ -15,6 +20,7 @@ export type ShutdownReason = ShutdownErrorReason | ShutdownUserClosedReason;
 export type IframeManagerOptions = {
   path: string;
   apiAuth: ComplyCoAPIAuth;
+  iframe: HTMLIFrameElement;
   events: {
     onLoad: (_: { iframe: HTMLIFrameElement }) => void;
     onShutdown: (reason: ShutdownReason) => void;
@@ -33,11 +39,8 @@ export default class IframeManager {
   }
 
   #initIframe() {
-    // TODO: Make sure 2 Iframes are not created
-    const iframe = document.createElement("iframe");
-    iframe.style.width = "100%";
-    iframe.style.height = "100%";
-    iframe.style.display = "none";
+    // NOTE: the caller should manage the iframe's visibility
+    const iframe = this.#options.iframe;
     iframe.src = this.#options.apiAuth.clientUrl(this.#options.path);
 
     iframe.onerror = (event, source, lineno, number, error) => {
@@ -48,7 +51,6 @@ export default class IframeManager {
     };
 
     this.#iframe = iframe;
-    document.body.appendChild(iframe);
   }
 
   #initCommunicator() {
@@ -132,7 +134,9 @@ export default class IframeManager {
     if (this.#communicator) {
       this.#communicator.removeListeners();
     }
-    this.#iframe?.parentNode?.removeChild(this.#iframe);
+    if (this.#iframe) {
+      this.#iframe.src = "";
+    }
     // TODO: Figure out if we need to clear out the iframe and communicator
   }
 }

--- a/packages/client-web/src/views/consents/details.ts
+++ b/packages/client-web/src/views/consents/details.ts
@@ -15,6 +15,7 @@ export function initialize(options: InitializeOptions) {
   const manager = new IframeManager({
     path: `/v1/consents/${options.params.id}`,
     apiAuth,
+    iframe: options.iframe,
     events: {
       onLoad: options.onLoad,
       onShutdown: options.onShutdown,

--- a/packages/client-web/src/views/tasks/details.ts
+++ b/packages/client-web/src/views/tasks/details.ts
@@ -15,6 +15,7 @@ export function initialize(options: InitializeOptions) {
   const manager = new IframeManager({
     path: `/v1/tasks/${options.params.id}`,
     apiAuth,
+    iframe: options.iframe,
     events: {
       onLoad: options.onLoad,
       onShutdown: options.onShutdown,

--- a/packages/client-web/src/views/tasks/list.ts
+++ b/packages/client-web/src/views/tasks/list.ts
@@ -16,6 +16,7 @@ export function initialize(options: InitializeOptions) {
   const manager = new IframeManager({
     path: "/v1/tasks",
     apiAuth,
+    iframe: options.iframe,
     events: {
       onLoad: options.onLoad,
       onShutdown: options.onShutdown,

--- a/packages/client-web/src/views/types.ts
+++ b/packages/client-web/src/views/types.ts
@@ -1,10 +1,14 @@
 import { type IframeManagerOptions } from "../iframe/manager";
 import { type ComplyCoAPIAuthOptions } from "../auth";
 
-export type ViewOptions = Pick<IframeManagerOptions["events"], "onLoad" | "onShutdown" | "onComplete" | "onResize" | "onHeartbeatAge"> & {
+export type ViewOptions = Pick<
+  IframeManagerOptions["events"],
+  "onLoad" | "onShutdown" | "onComplete" | "onResize" | "onHeartbeatAge"
+> & {
   baseUrl: string;
   onAuthTokenRequested: ComplyCoAPIAuthOptions["onGetAuthToken"];
   onError?: (error: any) => void;
+  iframe: HTMLIFrameElement;
 };
 
 // TODO: Add a function to validate the view options


### PR DESCRIPTION
We found that the iframe cannot be reliably moved from document.body into the location that the developer wishes without causing the iframe to unmount. This effect causes the React app that runs in the iframe to boot twice.

For more details, see notes in: https://linear.app/complyco/issue/ENG-339/scrolling-to-bottom-in-viewer-reloads-document