### PR TITLE
Switch from window.crypto.randomUUID to uuid package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8073,6 +8073,19 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
@@ -8640,7 +8653,8 @@
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@rrweb/record": "2.0.0-alpha.17",
-        "fflate": "^0.8.2"
+        "fflate": "^0.8.2",
+        "uuid": "^11.0.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/packages/client-recorder/package.json
+++ b/packages/client-recorder/package.json
@@ -50,7 +50,8 @@
   "dependencies": {
     "@babel/runtime": "^7.26.0",
     "@rrweb/record": "2.0.0-alpha.17",
-    "fflate": "^0.8.2"
+    "fflate": "^0.8.2",
+    "uuid": "^11.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/client-recorder/src/eventSaver.ts
+++ b/packages/client-recorder/src/eventSaver.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from "uuid";
 import type { Plugin, AuthTokenRequestFn, RequestHeadersAndBody } from "./types";
 
 export const DEFAULT_EVENT_SYNC_INTERVAL_MS = 5_000;
@@ -54,7 +55,7 @@ class EventSaver {
       return;
     }
 
-    const batchId = window.crypto.randomUUID();
+    const batchId = uuidv4();
     this.batches.set(batchId, {
       batchId,
       pageloadId: this.pageloadId,

--- a/packages/client-recorder/src/index.ts
+++ b/packages/client-recorder/src/index.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from "uuid";
 import { record } from "@rrweb/record";
 import type { AuthTokenRequestFn } from "./types";
 import EventSaver, { type EventSaverOptions, DEFAULT_EVENT_SYNC_INTERVAL_MS } from "./eventSaver";
@@ -21,7 +22,7 @@ class ClientRecorder {
   #onError: ((error: Error) => void) | undefined; // TODO: Wire this up
 
   constructor(options: ClientRecorderOptions) {
-    this.#pageloadId = window.crypto.randomUUID();
+    this.#pageloadId = uuidv4();
     this.#onError = (error: Error) => {
       // TODO: decide if we want to wrap errors in a custom error type
       if (options.onError) {


### PR DESCRIPTION
The `randomUUID` method is only callable from secure contexts (HTTPS): https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID. This prevents developers from testing recording on the localhost dev endpoints.

We want to provide a good developer experience and as such, we are switching to the uuid package which does not have this issue.