### PR TITLE
Expose maskAllInputs as a configuration

### DIFF
--- a/.changeset/bitter-peaches-worry.md
+++ b/.changeset/bitter-peaches-worry.md
@@ -1,0 +1,5 @@
+---
+"@complyco/client-recorder-web": patch
+---
+
+Make maskAllInputs configurable

--- a/packages/client-recorder/src/index.ts
+++ b/packages/client-recorder/src/index.ts
@@ -9,6 +9,7 @@ type ClientRecorderOptions = {
 };
 
 type RecordOptions = {
+  maskAllInputs?: boolean;
   blockClass?: string;
   ignoreClass?: string;
   maskTextClass?: string;
@@ -75,7 +76,7 @@ class ClientRecorder {
         headMetaAuthorship: true,
         headMetaVerification: true,
       },
-      maskAllInputs: true,
+      maskAllInputs: options.maskAllInputs ?? true,
       blockClass: options.blockClass || "complyco-block",
       ignoreClass: options.ignoreClass || "complyco-ignore",
       maskTextClass: options.maskTextClass || "complyco-mask",


### PR DESCRIPTION
This defaults to true, but we want to give users control.